### PR TITLE
Fix segmented sending for proactive replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug 修复
 
+- 修复主动回复进入 `OnDecoratingResultEvent` 后仍一次性发送整个 `MessageEventResult`，导致 AstrBot 分段回复配置未能按段落逐条发送的问题。
 - 修复主动回复绕过 AstrBot 发送前装饰阶段的问题。主动回复现在会构造 `MessageEventResult` 并触发 `OnDecoratingResultEvent`，确保消息分段、后置清理正则等插件 hook 能正常处理。
 - 修复 AstrBot 新版移除 `llm_compress_keep_recent` 后，主动回复构造 `MainAgentBuildConfig` 抛出 `unexpected keyword argument` 的问题。新版框架使用 `llm_compress_keep_recent_ratio`，旧版框架继续使用 `llm_compress_keep_recent`。
 

--- a/main.py
+++ b/main.py
@@ -1966,7 +1966,24 @@ class Conversa(Star):
 
                 decorated_result = send_event.get_result()
                 if decorated_result and decorated_result.chain:
-                    await send_event.send(decorated_result)
+                    if len(decorated_result.chain) > 1:
+                        for comp in decorated_result.chain:
+                            await send_event.send(decorated_result.derive([comp]))
+                            await asyncio.sleep(1.5)
+                    else:
+                        comp = decorated_result.chain[0]
+                        text_content = getattr(comp, "text", None)
+                        segments = (
+                            self._apply_segmentation(text_content)
+                            if isinstance(text_content, str)
+                            else []
+                        )
+                        if len(segments) > 1:
+                            for segment in segments:
+                                await send_event.send(send_event.plain_result(segment))
+                                await asyncio.sleep(1.5)
+                        else:
+                            await send_event.send(decorated_result)
                 send_event.clear_result()
                 return
 


### PR DESCRIPTION
## Summary
- make proactive replies send decorated message components one by one when decoration splits the result
- fall back to the plugin's existing regex segmentation when decoration leaves a single plain-text component
- keep the existing single-message behavior when no segmentation is produced

## Why
Conversa proactive replies currently trigger `OnDecoratingResultEvent`, then send the whole decorated `MessageEventResult` once through `send_event.send(decorated_result)`. That bypasses AstrBot's normal RespondStage per-component sending path, so AstrBot segmented reply settings do not take effect for Conversa output.

## Validation
- `D:\AstrBot\backend\python\python.exe -m py_compile main.py`

## Notes
- Not live-tested against a real AstrBot platform delivery session.